### PR TITLE
fix Class 'App\Veritrans\VeritransException' not found

### DIFF
--- a/app/Veritrans/Midtrans.php
+++ b/app/Veritrans/Midtrans.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace App\Veritrans;
-use App\Exceptions\VeritransException as Exception;
+use App\Exceptions\VeritransException as VeritransException;
 
 class Midtrans {
 
@@ -10,7 +10,7 @@ class Midtrans {
     * @static
     */
   public static $serverKey;
-  
+
   /**
     * true for production
     * false for sandbox mode
@@ -22,13 +22,13 @@ class Midtrans {
     * Default options for every request
     * @static
     */
-    public static $curlOptions = array(); 
+    public static $curlOptions = array();
 
     const SANDBOX_BASE_URL = 'https://api.sandbox.veritrans.co.id/v2';
     const PRODUCTION_BASE_URL = 'https://api.veritrans.co.id/v2';
     const SNAP_SANDBOX_BASE_URL = 'https://app.sandbox.midtrans.com/snap/v1';
     const SNAP_PRODUCTION_BASE_URL = 'https://app.midtrans.com/snap/v1';
-    
+
 
     public function config($params)
     {
@@ -81,7 +81,7 @@ class Midtrans {
    * @param bool    $post
    */
     public static function remoteCall($url, $server_key, $data_hash, $post = true)
-    { 
+    {
       $ch = curl_init();
 
       $curl_options = array(
@@ -144,7 +144,7 @@ class Midtrans {
 
   public static function getSnapToken($params)
   {
-    
+
     $result = Midtrans::post(
         Midtrans::getSnapBaseUrl() . '/transactions',
         Midtrans::$serverKey,
@@ -152,7 +152,7 @@ class Midtrans {
 
     return $result->token;
   }
-  
+
     /**
     * Retrieve transaction status
     * @param string $id Order ID or transaction ID

--- a/app/Veritrans/Veritrans.php
+++ b/app/Veritrans/Veritrans.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace App\Veritrans;
-use App\Exceptions\VeritransException as Exception;
+use App\Exceptions\VeritransException as VeritransException;
 
 Class Veritrans
 {
@@ -11,7 +11,7 @@ Class Veritrans
    	* @static
    	*/
 	public static $serverKey;
-	
+
 	/**
    	* true for production
    	* false for sandbox mode
@@ -23,7 +23,7 @@ Class Veritrans
    	* Default options for every request
    	* @static
    	*/
-  	public static $curlOptions = array();	
+  	public static $curlOptions = array();
 
   	const SANDBOX_BASE_URL = 'https://api.sandbox.veritrans.co.id/v2';
   	const PRODUCTION_BASE_URL = 'https://api.veritrans.co.id/v2';
@@ -73,8 +73,8 @@ Class Veritrans
 	 * @param bool    $post
 	 */
     public static function remoteCall($url, $server_key, $data_hash, $post = true)
-    {	
-    
+    {
+
 	    $ch = curl_init();
 
 	    $curl_options = array(
@@ -116,7 +116,7 @@ Class Veritrans
 
 	    $result = curl_exec($ch);
 	    // curl_close($ch);
-	   
+
 	    if ($result === FALSE) {
 	      throw new VeritransException('CURL Error: ' . curl_error($ch), curl_errno($ch));
 	    }
@@ -135,7 +135,7 @@ Class Veritrans
     }
 
     public function vtweb_charge($payloads)
-    {	
+    {
 
     	$result = Veritrans::post(
         Veritrans::getBaseUrl() . '/charge',
@@ -146,7 +146,7 @@ Class Veritrans
     }
 
     public function vtdirect_charge($payloads)
-    { 
+    {
 
       $result = Veritrans::post(
         Veritrans::getBaseUrl() . '/charge',


### PR DESCRIPTION
Change Exception to VeritransException
``
use App\Exceptions\VeritransException as Exception;
``
to
``
use App\Exceptions\VeritransException as VeritransException;
``